### PR TITLE
Refactor extraction into reusable `extractByMarkers` and update interpreters

### DIFF
--- a/app/logics/wikis/ExtractConvertInject.scala
+++ b/app/logics/wikis/ExtractConvertInject.scala
@@ -15,6 +15,18 @@ trait ExtractConvertInject {
 
   def extract(s: String): String
 
+  protected final def extractByMarkers(s: String, open: String = "[[[", close: String = "]]]"): String = {
+    if (s == null || !s.contains(open) || !s.contains(close)) {
+      s
+    } else {
+      val Array(head, remain) = s.split(java.util.regex.Pattern.quote(open), 2)
+      val Array(body, tail) = remain.split(java.util.regex.Pattern.quote(close), 2)
+      val uniqueKey = getUniqueKey
+      arrayBuffer += uniqueKey -> body
+      head + uniqueKey + extractByMarkers(tail, open, close)
+    }
+  }
+
   def convert(s: String)(implicit wikiContext: ContextWikiPage): String
 
   def inject(s: String)(implicit wikiContext: ContextWikiPage): String = {
@@ -27,4 +39,3 @@ trait ExtractConvertInject {
 
   def contains(s:String): Boolean = arrayBuffer.exists(_._1 == s)
 }
-

--- a/app/logics/wikis/ExtractConvertInjectInterpreter.scala
+++ b/app/logics/wikis/ExtractConvertInjectInterpreter.scala
@@ -10,15 +10,7 @@ class ExtractConvertInjectInterpreter() extends ExtractConvertInject {
   import models.tables.CalculatedSchemaOrg
 
   override def extract(s: String): String = {
-    if (s == null || !s.contains("[[[") || !s.contains("]]]")) {
-      s
-    } else {
-      val Array(head, remain) = s.split("""\[\[\[""", 2)
-      val Array(body, tail) = remain.split("""\]\]\]""", 2)
-      val uniqueKey = getUniqueKey
-      arrayBuffer += uniqueKey -> body
-      head + uniqueKey + extract(tail)
-    }
+    extractByMarkers(s)
   }
 
   override def convert(s: String)(implicit wikiContext: ContextWikiPage): String = Interpreters.toHtmlString(ShebangUtil.addWhenNotExist(s, "text"))
@@ -31,4 +23,3 @@ class ExtractConvertInjectInterpreter() extends ExtractConvertInject {
     arrayBuffer.map(_._2).flatMap(c => Interpreters.toSeqSchemaOrg(c)).toSeq
   }
 }
-

--- a/app/logics/wikis/ExtractConvertInjectInterpreterCustom.scala
+++ b/app/logics/wikis/ExtractConvertInjectInterpreterCustom.scala
@@ -5,17 +5,8 @@ import models.ContextWikiPage
 // TODO: Refactor this.
 class ExtractConvertInjectInterpreterCustom(converter:String => String) extends ExtractConvertInject {
   override def extract(s: String): String = {
-    if (s == null || !s.contains("[[[") || !s.contains("]]]")) {
-      s
-    } else {
-      val Array(head, remain) = s.split( """\[\[\[""", 2)
-      val Array(body, tail) = remain.split( """\]\]\]""", 2)
-      val uniqueKey = getUniqueKey
-      arrayBuffer += uniqueKey -> body
-      head + uniqueKey + extract(tail)
-    }
+    extractByMarkers(s)
   }
 
   override def convert(s: String)(implicit wikiContext: ContextWikiPage): String = converter(s)
 }
-


### PR DESCRIPTION
### Motivation

- Remove duplicated marker-extraction logic across implementations by centralizing it in the trait. 
- Make extraction robust to null/missing markers and allow configurable open/close markers. 
- Simplify interpreter classes and reduce future maintenance surface by consolidating behavior.

### Description

- Add `protected final def extractByMarkers(s: String, open: String = "[[[", close: String = "]]]")` to `ExtractConvertInject`, which safely handles `null`, uses `java.util.regex.Pattern.quote` when splitting, generates a unique key via `getUniqueKey`, stores the body in `arrayBuffer`, and recursively processes the tail. 
- Replace the inline marker extraction code in `ExtractConvertInjectInterpreter` and `ExtractConvertInjectInterpreterCustom` with calls to `extractByMarkers(s)`. 
- Preserve existing conversion/injection behavior and the `arrayBuffer` storage semantics; no changes to `convert`/`inject` APIs.

### Testing

- Ran `sbt compile` to ensure the project builds after the refactor and compilation succeeded. 
- Ran the existing automated test suite with `sbt test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e515fdcb708332a37f066748b4b702)